### PR TITLE
Updated both Edit and Create pages to render all game columns

### DIFF
--- a/app/assets/stylesheets/edit_game.css
+++ b/app/assets/stylesheets/edit_game.css
@@ -1,0 +1,3 @@
+.editform {
+    margin-bottom: 10px; /* Add space between form elements */
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -36,10 +36,6 @@ class GamesController < ApplicationController
 
   # PATCH/PUT /games/1 or /games/1.json
   def update
-    # if @game.game_title == "" || @game.game_title == nil
-    #   flash[:notice] = "Game Title can't be blank"
-    #   redirect_to game_path(@game)
-    # end
     respond_to do |format|
       if @game.update(game_params)
         format.html { redirect_to game_url(@game), notice: 'Game was successfully updated.' }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -94,6 +94,6 @@ class GamesController < ApplicationController
                                  :platform,
                                  :spanish,
                                  :other_languages,
-                                 :notes,)
+                                 :notes)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -36,6 +36,10 @@ class GamesController < ApplicationController
 
   # PATCH/PUT /games/1 or /games/1.json
   def update
+    # if @game.game_title == "" || @game.game_title == nil
+    #   flash[:notice] = "Game Title can't be blank"
+    #   redirect_to game_path(@game)
+    # end
     respond_to do |format|
       if @game.update(game_params)
         format.html { redirect_to game_url(@game), notice: 'Game was successfully updated.' }
@@ -66,6 +70,34 @@ class GamesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def game_params
-    params.require(:game).permit(:game_title, :url)
+    params.require(:game).permit(:game_title,
+                                 :url,
+                                 :source,
+                                 :researcher,
+                                 :included,
+                                 :exclusion_notes,
+                                 :publication_year,
+                                 :developers,
+                                 :publisher,
+                                 :used_in_class,
+                                 :downloadable,
+                                 :discontinued,
+                                 :generalized_subject,
+                                 :subject1,
+                                 :subject2,
+                                 :remainder,
+                                 :teaching,
+                                 :college_users,
+                                 :cost,
+                                 :game_type,
+                                 :genre,
+                                 :tags,
+                                 :game_time,
+                                 :dimensions,
+                                 :sound,
+                                 :platform,
+                                 :spanish,
+                                 :other_languages,
+                                 :notes,)
   end
 end

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -11,14 +11,111 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :game_title, style: "display: block" %>
-    <%= form.text_field :game_title %>
+  <div class="editform">
+    <%= form.label :game_title, 'Game Title', :class => 'col-form-label' %>
+    <%= form.text_field 'game_title', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :url, 'URL', :class => 'col-form-label' %>
+    <%= form.text_field 'url', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :source, 'Source', :class => 'col-form-label' %>
+    <%= form.text_field 'source', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :researcher, 'Researcher', :class => 'col-form-label' %>
+    <%= form.text_field 'researcher', :class => 'form-control' %>
   </div>
 
-  <div>
-    <%= form.label :url, style: "display: block" %>
-    <%= form.text_area :url %>
+  <div class="editform">
+    <%= form.label :publication_year, 'Publication Year', :class => 'col-form-label'  %>
+    <%= form.text_field 'publication_year', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :developers, 'Developers', :class => 'col-form-label' %>
+    <%= form.text_field 'developers', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :publisher, 'Publisher', :class => 'col-form-label' %>
+    <%= form.text_field 'publisher', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <!--  This could be a check_box-->
+    <%= form.label :used_in_class, 'Is this game used in classrooms? (Y/N)', :class => 'col-form-label' %>
+    <%= form.text_field 'used_in_class', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :downloadable, 'Is this game downloadable? (Y/N)', :class => 'col-form-label' %>
+    <%= form.text_field 'downloadable', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :discontinued, 'Is support discontinued for this game? (Y/N)', :class => 'col-form-label' %>
+    <%= form.text_field 'discontinued', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :generalized_subject, 'Generalized Subject', :class => 'col-form-label' %>
+    <%= form.text_field 'generalized_subject', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :subject1, 'Primary Subject', :class => 'col-form-label' %>
+    <%= form.text_field 'subject1', :class => 'form-control' %>
+    <%= form.label :subject2, 'Secondary Subject', :class => 'col-form-label' %>
+    <%= form.text_field 'subject2', :class => 'form-control' %>
+    <%= form.label :remainder, 'Any other Subjects?', :class => 'col-form-label' %>
+    <%= form.text_field 'remainder', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :teaching, 'Teaching', :class => 'col-form-label' %>
+    <%= form.text_field 'teaching', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :college_users, 'Which colleges use this game?', :class => 'col-form-label' %>
+    <%= form.text_field 'college_users', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :cost, 'Cost', :class => 'col-form-label' %>
+    <%= form.text_field 'cost', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :game_type, 'Game Type', :class => 'col-form-label' %>
+    <%= form.text_field 'game_type', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :genre, 'Genre', :class => 'col-form-label' %>
+    <%= form.text_field 'genre', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :tags, 'Tags', :class => 'col-form-label' %>
+    <%= form.text_field 'tags', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :game_time, 'Game Length (Hours)', :class => 'col-form-label' %>
+    <%= form.text_field 'game_time', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :dimensions, 'Dimensions (2D/3D)', :class => 'col-form-label' %>
+    <%= form.text_field 'dimensions', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :sound, 'Does this game have sound? (Y/N)', :class => 'col-form-label' %>
+    <%= form.text_field 'sound', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :platform, 'Platform', :class => 'col-form-label' %>
+    <%= form.text_field 'platform', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :spanish, 'Is this game available in Spanish? (Y/N)', :class => 'col-form-label' %>
+    <%= form.text_field 'spanish', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :other_languages, 'What other languages is this game available in?', :class => 'col-form-label' %>
+    <%= form.text_field 'other_languages', :class => 'form-control' %>
+  </div>
+  <div class="editform">
+    <%= form.label :notes, 'Notes', :class => 'col-form-label' %>
+    <%= form.text_field 'notes', :class => 'form-control' %>
   </div>
 
   <div>

--- a/app/views/games/edit.html.erb
+++ b/app/views/games/edit.html.erb
@@ -1,4 +1,11 @@
-<h1>Editing game</h1>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="edit_game.css">
+</head>
+
+<h2>Editing <%= @game.game_title %></h2>
+<br>
 
 <%= render "form", game: @game %>
 
@@ -6,5 +13,5 @@
 
 <div>
   <%= link_to "Show this game", @game %> |
-  <%= link_to "Back to games", games_path %>
+  <%= link_to 'Cancel Edit', games_path, :class => 'btn btn-secondary' %>
 </div>

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -1,5 +1,5 @@
 
-<h1>New Game</h1>
+<h2>Creating New Game</h2>
 
 <%= render "form", game: @game %>
 

--- a/db/migrate/20240213035850_create_games.rb
+++ b/db/migrate/20240213035850_create_games.rb
@@ -3,7 +3,7 @@
 class CreateGames < ActiveRecord::Migration[7.1]
   def change # rubocop:disable Metrics/MethodLength
     create_table :games do |g| # rubocop:disable Metrics/BlockLength
-      g.string 'game_title'
+      g.string 'game_title', null: false
       g.string 'url'
       g.string 'source'
       g.string 'researcher'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema[7.1].define(version: 2024_02_13_035850) do
   create_table "games", force: :cascade do |t|
-    t.string "game_title"
+    t.string "game_title", null: false
     t.string "url"
     t.string "source"
     t.string "researcher"

--- a/features/game_management.feature
+++ b/features/game_management.feature
@@ -9,14 +9,14 @@ Feature: Game management
   Scenario: Creating a new game
     Given I am on the game list page
     When I click "New Game"
-    And I fill in "Game title" with "New Game"
-    And I fill in "Url" with "http://newgame.com"
+    And I fill in "Game Title" with "New Game"
+    And I fill in "URL" with "http://newgame.com"
     And I click "Create Game" button
     Then I should be on the "New Game" details page
 
   Scenario: Unsuccessful creation of a game
     Given I am on the new game page
-    When I fill in "Game title" with ""
+    When I fill in "Game Title" with ""
     And I click "Create Game" button
     Then I should see "can't be blank"
 
@@ -30,13 +30,13 @@ Feature: Game management
   Scenario: Updating a game
     Given I am on the "Game1" details page
     When I click "Edit this game"
-    And I fill in "Game title" with "Game1 Updated"
+    And I fill in "Game Title" with "Game1 Updated"
     And I click "Update Game" button
     Then I should be on the "Game1 Updated" details page
 
   Scenario: Unsuccessful game update due to invalid input
     Given I am on the "Game1" edit page
-    When I fill in "Game title" with ""
+    When I fill in "Game Title" with ""
     And I click "Update Game" button
     Then I should see "can't be blank"
 


### PR DESCRIPTION
PR addresses both:
Modify the “edit” page of game views, to show the new columns and make them editable.
Modify the “new” page of game views, to add text input boxes for the new columns

All Cucumber scenarios passing, all rspec passing

New Page example:
<img width="1493" alt="image" src="https://github.com/yeonchae62/LIVE/assets/157041689/293679a3-c09d-4734-bf97-6a4d8ce77414">

Edit Page Example:
<img width="1481" alt="image" src="https://github.com/yeonchae62/LIVE/assets/157041689/a58ecac2-d8b0-43ed-af60-660723a08ca6">

Both Edit and New Game pages reject nil title:
<img width="1293" alt="image" src="https://github.com/yeonchae62/LIVE/assets/157041689/4b3aa5a0-7c69-49ad-b61e-081ee24cd9d6">
